### PR TITLE
Fix: responsivibility problem with 1024 screens

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -67,3 +67,9 @@ a {
 .footer__link-separator {
   display: none;
 }
+
+@media screen and (max-width: 1190px) {
+  .navbar__items {
+    font-size: 0.75rem;
+  }
+}


### PR DESCRIPTION
Resolved an issue where the navbar was collapsing unexpectedly on screens with a width of 1024 pixels.

Before:
![obraz](https://github.com/user-attachments/assets/2cfe8e85-91f6-419d-94b4-555a2b0d09f9)

After:
![obraz](https://github.com/user-attachments/assets/bd45beb6-da2e-4ab1-b224-feb7d2dcc9a0)

